### PR TITLE
add native OS notifications

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,5 @@ tokio = { version = "1.0.0", features = ["full"] }
 futures = "0.3"
 home = "0.5.3"
 thiserror = "1.0.29"
+chrono = "0.4.19"
+notify-rust = "4"

--- a/src/core/conversations.rs
+++ b/src/core/conversations.rs
@@ -1,7 +1,9 @@
 use std::{collections::HashMap, str::FromStr};
 
 use super::{config::Contact, user::User};
+use chrono::Duration;
 use nostr::{util::nip04::decrypt, Event};
+use notify_rust::Notification;
 use secp256k1::schnorrsig::PublicKey;
 use thiserror::Error;
 use tokio::sync::broadcast;
@@ -68,7 +70,9 @@ impl Conversations {
                 match decrypt(&sk, &peer_pk, &ev.content) {
                     Ok(decrypted_msg) => {
                         let new_msg = Message::new(source, &decrypted_msg, ev);
+
                         conv.add_message(new_msg.clone());
+
                         //Send notification to listeners
                         self.conv_noti_sender
                             .send(ConvsNotifications::NewMessage(new_msg));
@@ -124,6 +128,22 @@ impl Conversation {
     }
 
     fn add_message(&mut self, message: Message) {
+        // If the message is from Them, and is less than one minute old, show an OS notification
+        let current_time = chrono::offset::Utc::now();
+
+        if message.ev.created_at > current_time - Duration::seconds(60) {
+            if message.source == MessageSource::Them {
+                if Notification::new()
+                    .summary(&self.contact.alias)
+                    .body(&message.content)
+                    .show()
+                    .is_err()
+                {
+                    eprintln!("Couldn't show OS notification")
+                }
+            }
+        }
+
         self.messages.push(message);
         self.messages
             .sort_by(|a, b| a.ev.created_at.cmp(&b.ev.created_at));
@@ -147,7 +167,7 @@ impl Message {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum MessageSource {
     Me,
     Them,

--- a/src/core/relay_pool.rs
+++ b/src/core/relay_pool.rs
@@ -31,7 +31,7 @@ impl RelayPoolTask {
     async fn handle_message(&mut self, msg: RelayPoolEv) {
         match msg {
             RelayPoolEv::ReceivedMsg { relay_url, msg } => {
-                dbg!("Received message from {}: {:?}", &relay_url, &msg);
+                dbg!(format!("Received message from {}: {:?}", &relay_url, &msg));
                 match msg {
                     RelayMessage::Event {
                         event,


### PR DESCRIPTION
very simple PR for native OS notifications. only tested on mac but the library I used is supposed to be cross platform

kind of lame that I need chrono for this. I think maybe we should just start using simple u64 utc timestamps nostr-rs and try to get away from chrono entirely